### PR TITLE
add a meta file

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,21 @@
+galaxy_info:
+  role_name: caddy
+  author: angristan
+  description: Ansible role for Caddy
+  license: MIT
+  min_ansible_version: 2.4
+
+  platforms:
+  - name: Debian
+    versions:
+    - all
+  - name: Ubuntu
+    versions:
+    - all
+
+  galaxy_tags:
+    - caddy
+    - debian
+    - ubuntu
+
+dependencies: []


### PR DESCRIPTION
I'm an ansible newbie, but according to [TFM](https://galaxy.ansible.com/docs/contributing/creating_role.html#role-metadata) and looking at your other roles, I think metadata is needed in order to import the role as described [here](https://github.com/angristan/ansible-caddy#usage)

Pls let me know if anything needs correcting, or if this is not needed.